### PR TITLE
Minor usability adjustments

### DIFF
--- a/Solarized-dark.css
+++ b/Solarized-dark.css
@@ -6,7 +6,6 @@
 @base {
     color: #839496;
     background-color: #002b36;
-    insertion-point-color: #dc322f;
 }
 
 * {

--- a/Solarized-dark.css
+++ b/Solarized-dark.css
@@ -7,7 +7,6 @@
     color: #839496;
     background-color: #002b36;
     insertion-point-color: #dc322f;
-    selection-background-color: #dc322f;
 }
 
 * {

--- a/Solarized-light.css
+++ b/Solarized-light.css
@@ -6,8 +6,6 @@
 @base {
     color: #657b83;
     background-color: #fdf6e3;
-    insertion-point-color: #dc322f;
-    selection-background-color: #dc322f;
 }
 
 * {

--- a/Solarized-light.css
+++ b/Solarized-light.css
@@ -1,5 +1,5 @@
 /*
-    @theme Solarized-dark
+    @theme Solarized-light
     @override-placeholders html, css, js, php, python
 */
 


### PR DESCRIPTION
First and foremost: kudos and thanks for porting Solarized to Espresso! I have found, however, that some minor adjustments improve the usability of the themes:
1. I have corrected the internal name (used by Espresso) of the light scheme to Solarized-light
2. _this might be controversial, but here goes:_ I have removed the selection and insertion-point color definitions, as I found them both jarring and actually far less readable than the system colors (especially selection color, which will blot out some tokens).
